### PR TITLE
Add more citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ It may also be a good idea to add the specific version of Python, for example fo
 
 Packages are listed alphabetically. If this list grows too long, maybe we can add categories.
 
+### CoreNLP BibTeX citation
+
+```bibtex
+@InProceedings{manning-EtAl:2014:P14-5,
+  author    = {Manning, Christopher D. and  Surdeanu, Mihai  and  Bauer, John  and  Finkel, Jenny  and  Bethard, Steven J. and  McClosky, David},
+  title     = {The {Stanford} {CoreNLP} Natural Language Processing Toolkit},
+  booktitle = {Association for Computational Linguistics (ACL) System Demonstrations},
+  year      = {2014},
+  pages     = {55--60},
+  url       = {http://www.aclweb.org/anthology/P/P14/P14-5010}
+}
+```
+
 ### Keras BibTeX citation
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ It may also be a good idea to add the specific version of Python, for example fo
 
 Packages are listed alphabetically. If this list grows too long, maybe we can add categories.
 
+### Caffe BibTeX citation
+
+```bibtex
+@inproceedings{jia2014caffe,
+  title={Caffe: Convolutional architecture for fast feature embedding},
+  author={Jia, Yangqing and Shelhamer, Evan and Donahue, Jeff and Karayev, Sergey and Long, Jonathan and Girshick, Ross and Guadarrama, Sergio and Darrell, Trevor},
+  booktitle={Proceedings of the 22nd ACM international conference on Multimedia},
+  pages={675--678},
+  year={2014},
+  organization={ACM}
+}
+```
+
 ### CoreNLP BibTeX citation
 
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
   Year = {2014}
 }
 ```
+
 ([source](https://caffe.berkeleyvision.org/))
 
 ### CoreNLP BibTeX citation
@@ -65,7 +66,8 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
   url       = {http://www.aclweb.org/anthology/P/P14/P14-5010}
 }
 ```
-([source](https://stanfordnlp.github.io/CoreNLP/citing.html))
+([source
+](https://stanfordnlp.github.io/CoreNLP/citing.html))
 
 ### Keras BibTeX citation
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,20 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
 }
 ```
 
+### Theano BibTeX citation
+
+```bibtex
+@inproceedings{bergstra2010theano,
+  title={Theano: a CPU and GPU math expression compiler},
+  author={Bergstra, James and Breuleux, Olivier and Bastien, Fr{\'e}d{\'e}ric and Lamblin, Pascal and Pascanu, Razvan and Desjardins, Guillaume and Turian, Joseph and Warde-Farley, David and Bengio, Yoshua},
+  booktitle={Proceedings of the Python for scientific computing conference (SciPy)},
+  volume={4},
+  number={3},
+  year={2010},
+  organization={Austin, TX}
+}
+```
+
 ([source](https://www.tensorflow.org/about/bib))
 
 # Credits

--- a/README.md
+++ b/README.md
@@ -44,15 +44,14 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
 ### Caffe BibTeX citation
 
 ```bibtex
-@inproceedings{jia2014caffe,
-  title={Caffe: Convolutional architecture for fast feature embedding},
-  author={Jia, Yangqing and Shelhamer, Evan and Donahue, Jeff and Karayev, Sergey and Long, Jonathan and Girshick, Ross and Guadarrama, Sergio and Darrell, Trevor},
-  booktitle={Proceedings of the 22nd ACM international conference on Multimedia},
-  pages={675--678},
-  year={2014},
-  organization={ACM}
+@article{jia2014caffe,
+  Author = {Jia, Yangqing and Shelhamer, Evan and Donahue, Jeff and Karayev, Sergey and Long, Jonathan and Girshick, Ross and Guadarrama, Sergio and Darrell, Trevor},
+  Journal = {arXiv preprint arXiv:1408.5093},
+  Title = {Caffe: Convolutional Architecture for Fast Feature Embedding},
+  Year = {2014}
 }
 ```
+([source](https://caffe.berkeleyvision.org/))
 
 ### CoreNLP BibTeX citation
 
@@ -66,16 +65,20 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
   url       = {http://www.aclweb.org/anthology/P/P14/P14-5010}
 }
 ```
+([source](https://stanfordnlp.github.io/CoreNLP/citing.html))
 
 ### Keras BibTeX citation
 
 ```bibtex
 @misc{chollet2015keras,
   title={Keras},
-  author={Chollet, Fran{\c{c}}ois and others},
-  year={2015}
+  author={Chollet, Fran\c{c}ois and others},
+  year={2015},
+  howpublished={\url{https://keras.io}},
 }
 ```
+
+([source](https://keras.io/getting-started/faq/))
 
 ### Matplotlib BibTeX citation
 
@@ -266,21 +269,25 @@ Packages are listed alphabetically. If this list grows too long, maybe we can ad
 }
 ```
 
+([source](https://www.tensorflow.org/about/bib))
+
 ### Theano BibTeX citation
 
 ```bibtex
-@inproceedings{bergstra2010theano,
-  title={Theano: a CPU and GPU math expression compiler},
-  author={Bergstra, James and Breuleux, Olivier and Bastien, Fr{\'e}d{\'e}ric and Lamblin, Pascal and Pascanu, Razvan and Desjardins, Guillaume and Turian, Joseph and Warde-Farley, David and Bengio, Yoshua},
-  booktitle={Proceedings of the Python for scientific computing conference (SciPy)},
-  volume={4},
-  number={3},
-  year={2010},
-  organization={Austin, TX}
+@ARTICLE{2016arXiv160502688short,
+   author = {{Theano Development Team}},
+    title = "{Theano: A {Python} framework for fast computation of mathematical expressions}",
+  journal = {arXiv e-prints},
+   volume = {abs/1605.02688},
+ primaryClass = "cs.SC",
+ keywords = {Computer Science - Symbolic Computation, Computer Science - Learning, Computer Science - Mathematical Software},
+     year = 2016,
+    month = may,
+      url = {http://arxiv.org/abs/1605.02688},
 }
 ```
 
-([source](https://www.tensorflow.org/about/bib))
+([source](http://deeplearning.net/software/theano/citation.html))
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ It may also be a good idea to add the specific version of Python, for example fo
 
 Packages are listed alphabetically. If this list grows too long, maybe we can add categories.
 
+### Keras BibTeX citation
+
+```bibtex
+@misc{chollet2015keras,
+  title={Keras},
+  author={Chollet, Fran{\c{c}}ois and others},
+  year={2015}
+}
+```
+
 ### Matplotlib BibTeX citation
 
 ```bibtex


### PR DESCRIPTION
Added citations and sources for Keras, CoreNLP, Theano, and Caffe.

If this gets too long, I think a branch separating into core ecosystem (numpy, etc.), deep learning (tensorflow, pytorch, etc), and NLP (spacy, corenlp, etc) would be useful.