### PR TITLE
Add imbalanced-learn BibTex citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,21 @@ See also: ([DOIs per version of Matplotlib](https://matplotlib.org/3.1.0/citing.
 ```
 ([source](https://github.com/leonoverweel/bibtex-python-package-citations/issues/1))
 
+### Imbalanced-learn BibTex citation
+
+```
+@article{imbalanced-learn,
+author  = {Guillaume  Lema{{\^i}}tre and Fernando Nogueira and Christos K. Aridas},
+title   = {Imbalanced-learn: A Python Toolbox to Tackle the Curse of Imbalanced Datasets in Machine Learning},
+journal = {Journal of Machine Learning Research},
+year    = {2017},
+volume  = {18},
+number  = {17},
+pages   = {1-5},
+url     = {http://jmlr.org/papers/v18/16-365.html}
+}
+```
+([source](https://imbalanced-learn.org/stable/about.html#citing-imbalanced-learn))
 
 # Acknowledgements
 


### PR DESCRIPTION
First things first, your README.md is pure gold 🥇. I was having a hard time finding good BibTex citations for my academic thesis.

I'm adding the BibTex citation for the [`imbalanced-learn`](https://imbalanced-learn.org/stable/index.html) python package, which aids in dealing with imbalanced datasets.